### PR TITLE
allow for @extend p and @extend .h6

### DIFF
--- a/lib/replacements/@extend.js
+++ b/lib/replacements/@extend.js
@@ -1,6 +1,6 @@
 // TODO: mimic LESS's &:extend(x all)
 module.exports = {
-  pattern: /@extend\s\.([a-zA-Z-_]*)/gi,
-  replacement: '&:extend(.$1)',
+  pattern: /@extend[^\S\n]([\w\-\.\#]*)/gi,
+  replacement: '&:extend($1 all)',
   order: 2
 }

--- a/spec/expected/@extend.less
+++ b/spec/expected/@extend.less
@@ -2,6 +2,18 @@
   border: 1px #f00;
 }
 .seriousError {
-  &:extend(.error);
+  &:extend(.error all);
   border-width: 3px;
+}
+p {
+  color: #f00;
+}
+.p {
+  &:extend(p all);
+}
+.som3-thing {
+  color: #0f0;
+}
+.somet1ing-else {
+  &:extend(.som3-thing all)
 }

--- a/spec/expected/variables.less
+++ b/spec/expected/variables.less
@@ -8,9 +8,9 @@
  opacity: 1;
 }
 
-@-webkit-keyframes fadein { &:extend(.fadeIn); }
-@-moz-keyframes fadein { &:extend(.fadeIn); }
-@keyframes fadein { &:extend(.fadeIn); }
+@-webkit-keyframes fadein { &:extend(.fadeIn all); }
+@-moz-keyframes fadein { &:extend(.fadeIn all); }
+@keyframes fadein { &:extend(.fadeIn all); }
 
 @font-face {
   font-family: 'Open Sans';

--- a/spec/fixtures/@extend.scss
+++ b/spec/fixtures/@extend.scss
@@ -5,3 +5,15 @@
   @extend .error;
   border-width: 3px;
 }
+p {
+  color: #f00;
+}
+.p {
+  @extend p;
+}
+.som3-thing {
+  color: #0f0;
+}
+.somet1ing-else {
+  @extend .som3-thing
+}


### PR DESCRIPTION
Resolves the following issues:

**SCSS**
```
.p {
  @extend p;
}
```
**LESS**
```
.p {
  @extend p;
}
```
**SCSS**
```
.some-title {
  @extend .h6;
}
```
**LESS**
```
.some-title {
  &:extend(.h)6;
}
```

Additionally uses less all for extends as this seems to match scss better.