### PR TITLE
Remove lodash dependency.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 let fs = require('fs')
-let _ = require('lodash')
 let dir = __dirname + '/replacements/'
 let sassToLess = function() {}
 
@@ -10,7 +9,7 @@ let replacements = function () {
     return require(dir + filename)
   })
 
-  return _.sortBy(results, 'order')
+  return results.sort(function (a, b) { return a.order > b.order ? 1 : -1; });
 }
 
 sassToLess.prototype = {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "mediafreakch",
   "dependencies": {
     "cli": "^1.0.1",
-    "lodash": "^4.17.2",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If it's just being used for the result sort then it's a bit heavy, especially for build tools that bundle plugins for their LESS pipelines.